### PR TITLE
Added Fate Stay Night Unlimited Blade Works

### DIFF
--- a/custom_mappings.yaml
+++ b/custom_mappings.yaml
@@ -65,6 +65,13 @@ entries:
       - season: 1
         anilist-id: 20792
         start: 13
+  - title: "Fate/Zero"
+    seasons:
+      - season: 1
+        anilist-id: 10087
+      - season: 1
+        anilist-id: 11741
+        start: 13
   - title: "Gintama"
     seasons:
       - season: 1

--- a/custom_mappings.yaml
+++ b/custom_mappings.yaml
@@ -57,6 +57,14 @@ entries:
         anilist-id: 105333
       - season: 2
         anilist-id: 113936
+  - title: "Fate/stay night: Unlimited Blade Works"
+    seasons:
+      - season: 1
+        anilist-id: 19603
+        start: 2
+      - season: 1
+        anilist-id: 20792
+        start: 13
   - title: "Gintama"
     seasons:
       - season: 1


### PR DESCRIPTION
```
  - title: "Fate/stay night: Unlimited Blade Works"
    seasons:
      - season: 1
        anilist-id: 19603
        start: 2
      - season: 1
        anilist-id: 20792
        start: 13
```
Starts at ep 2 to sync TVDB episode count [25] to Anilist[13+13] because Anilist includes "Prolouge Special Episode" as Episode 1 of Season 1 while TVDB lists it as a special.