### PR TITLE
Add Soitora's mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Currently Mapped Titles:
 | The Irregular at Magic High School | Series | S01, S02 | S01, Visitor Arc |  |
 | The King's Avatar | Series | S01, S02, S03 | S01, S02, S03 |  |
 | The Melancholy of Haruhi Suzumiya | Series | S01 | The Melancholy of Haruhi Suzumiya (2009) |  |
-| The Rising of the Shield Hero | Series | S01 | The Rising of the Shield Hero |  |
+| The Rising of the Shield Hero | Series | S01, S02, S03 | S01, S02, S03 |  |
 | The Slime Diaries | Series | S01 | The Slime Diaries |  |
 | Tokyo Ghoul | Series | S01, S02, S03 | Tokyo Ghoul, √A, re: + re:2 |  |
 | Twin Star Exorcists | Series | S01 | S01 |  |

--- a/custom_mappings.yaml
+++ b/custom_mappings.yaml
@@ -486,6 +486,10 @@ entries:
     seasons:
       - season: 1
         anilist-id: 99263
+      - season: 2
+        anilist-id: 111321
+      - season: 3
+        anilist-id: 111322
   - title: "The Slime Diaries"
     seasons:
       - season: 1


### PR DESCRIPTION
**Work done on top of #10**

Cleaned some stuff for the `README`

### Fixed
- Attack on Titan
  - Was missing S03P2 from mapping
- Demon Slayer: Kimetsu no Yaiba
  - Missing ': Kimetsu no Yaiba' from title
- Re:ZERO -Starting Life in Another World-
  - Was missing S01 from mapping

### Added
- Aldnoah.Zero
- BEASTARS
- Blood Blockade Battlefront
- Boruto: Naruto Next Generations
- Chaika the Coffin Princess
- Darker Than Black
- Durarara!!
- Food Wars! Shokugeki no Soma
- Fruits Basket
- Grimgar of Fantasy & Ash
- Haikyu!!
- Hozuki's Coolheadedness
- Hunter x Hunter
- Inu x Boku Secret Service
- Is It Wrong to Try to Pick Up Girl in a Dungeon?
- K
- Kaguya-sama: Love is War (S3)
- Kakegurui
- Kingdom
- Log Horizon
- Love, Chunibyo & Other Delusions!
- Magi: Adventure of Sinbad
- Magi: The Labyrinth of Magic
- Megalobox
- My Teen Romantic Comedy SNAFU
- Noragami
- One Piece
- Psycho-Pass
- Rage of Bahamut
- Seraph of the End
- Star Blazers: Space Battleship Yamato 2199
- Sweetness & Lightning
- The Irregular at Magic High School
- The King's Avatar
- The Rising of the Shield Hero (S2 and S3)
- Twin Star Exorcists
- Yamada-kun and the Seven Witches