### PR TITLE
Added Bungo stray dogs

### DIFF
--- a/custom_mappings.yaml
+++ b/custom_mappings.yaml
@@ -338,6 +338,21 @@ entries:
     seasons:
       - season: 1
         anilist-id: 97938
+  - title: Bungo Stray Dogs
+    synonyms:
+      - "Bungou Stray Dogs"
+      -"文豪ストレイドッグス"
+    seasons:
+      - season: 1
+        anilist-id: 21311
+        start: 1
+      - season: 2
+        anilist-id: 21679
+        start: 13
+      - season: 3
+        anilist-id: 103223
+      - season: 4
+        anilist-id: 141249
   - title: "By the Grace of the Gods"
     synonyms:
       - "神達に拾われた男"

--- a/custom_mappings.yaml
+++ b/custom_mappings.yaml
@@ -341,7 +341,7 @@ entries:
   - title: Bungo Stray Dogs
     synonyms:
       - "Bungou Stray Dogs"
-      -"文豪ストレイドッグス"
+      - "文豪ストレイドッグス"
     seasons:
       - season: 1
         anilist-id: 21311


### PR DESCRIPTION
TVDB S01 (24 Episodes) = Anilist S01 (12 episodes) + Anilist S02 (12 episodes)
TVDB S02 (12Episodes) = Anilist S03 (12 episodes)
TVDB S03 (12Episodes) = Anilist S04 (12 episodes)

https://thetvdb.com/series/bungo-stray-dogs#seasons
https://anilist.co/anime/21311/Bungo-Stray-Dogs/
https://anilist.co/anime/21679/Bungo-Stray-Dogs-2/
https://anilist.co/anime/103223/Bungo-Stray-Dogs-3/
https://anilist.co/anime/141249/Bungo-Stray-Dogs-4/