### PR TITLE
Bungo Stray Dogs wrong mapping fix

### DIFF
--- a/custom_mappings.yaml
+++ b/custom_mappings.yaml
@@ -470,10 +470,14 @@ entries:
       - season: 1
         anilist-id: 21679
         start: 13
-      - season: 3
+      - season: 2
         anilist-id: 103223
-      - season: 4
+      - season: 3
         anilist-id: 141249
+        start: 1
+      - season: 3
+        anilist-id: 163263
+        start: 14
   - title: "By the Grace of the Gods"
     synonyms:
       - "神達に拾われた男"

--- a/custom_mappings.yaml
+++ b/custom_mappings.yaml
@@ -467,7 +467,7 @@ entries:
       - season: 1
         anilist-id: 21311
         start: 1
-      - season: 2
+      - season: 1
         anilist-id: 21679
         start: 13
       - season: 3
@@ -1752,6 +1752,8 @@ entries:
   - title: "KONOSUBA -An Explosion on This Wonderful World!"
     synonyms:
       - "Kono Subarashii Sekai ni Bakuen wo!"
+      - "Kono Subarashii Sekai ni Bakuen o!"
+      - "この素晴らしい世界に爆焔を！"
     seasons:
       - season: 1
         anilist-id: 150075

--- a/custom_mappings.yaml
+++ b/custom_mappings.yaml
@@ -1753,6 +1753,7 @@ entries:
     synonyms:
       - "Kono Subarashii Sekai ni Bakuen wo!"
       - "Kono Subarashii Sekai ni Bakuen o!"
+      - "KonoSuba – An Explosion on This Wonderful World!"
       - "この素晴らしい世界に爆焔を！"
     seasons:
       - season: 1


### PR DESCRIPTION
Fixed Bungo Stray Dogs wrong mapping for Season 1 and added an alternative title for Kono Subarashii Sekai ni Bakuen o! because of HAMA titles.