### PR TITLE
Fix season mapping for Fire Force

### DIFF
--- a/custom_mappings.yaml
+++ b/custom_mappings.yaml
@@ -934,8 +934,10 @@ entries:
       - "炎炎ノ消防隊"
     seasons:
       - season: 1
-        anilist-id: 114236
+        anilist-id: 105310
       - season: 2
+        anilist-id: 114236
+      - season: 3
         anilist-id: 149118
   - title: "FLCL"
     synonyms:


### PR DESCRIPTION
Noticed season 1/2 were mapped to 2/3 respectively when I saw my AniList had incorrectly marked me watching S3 (it's not out yet)