### PR TITLE
Fix Nier season mapping

### DIFF
--- a/custom_mappings.yaml
+++ b/custom_mappings.yaml
@@ -2737,7 +2737,7 @@ entries:
     seasons:
       - season: 1
         anilist-id: 145665
-      - season: 2
+      - season: 1
         anilist-id: 167420
         start: 13
   - title: "Nisekoi"


### PR DESCRIPTION
TVDB lists Nier as 1 season only, fixing mapping for second cour.